### PR TITLE
fix: githubApiToken not equal lead to bad credentials #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-
 ---
-
 <p align="center" >
-  <strong>GitHub Statistics</strong>
+<strong>GitHub Statistics</strong>
 </p>
-
 ---
 
 ![trynow](https://img.shields.io/badge/TRY-NOW-green?url=https://vesoft-inc.github.io/github-statistics/)
@@ -23,7 +20,7 @@
 
 ![Image of Yaktocat](/src/image/WX20190912-173245.png)
 
-# Features (WIP)
+# Features
 
 - [x] Repository overview
 - [x] Star history
@@ -41,18 +38,32 @@ Feature requests are also warmly welcomed.
 
 # Development
 
-1. `git clone` and `npm -i` to set up the enviroment.
+1. clone repo.
 
-2. set `YOUR_GITHUB_API_TOKEN` in the [.env](./.env) file.
+```shell
+git clone https://github.com/vesoft-inc/github-statistics.git
+```
 
-3. `npm start`
+2. install npm modules.
 
-Runs the app in the development mode.<br>
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+```shell
+cd github-statistics
+npm install
+```
 
-`npm run build`
+3. **MUST SET** `YOUR_GITHUB_API_TOKEN` in the [.env](./.env) file. Read [Creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) to create token if you don't have one.
 
-Builds the app for production to the `build` folder.<br>
+4. runs the app in the development mode, open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+
+```shell
+npm start
+```
+
+Build the app for production to the `build` folder.<br>
+
+```shell
+npm run build
+```
 
 ---
 

--- a/src/components/GithubStatistics.js
+++ b/src/components/GithubStatistics.js
@@ -41,7 +41,7 @@ class GithubStatistics extends React.Component {
     /* eslint-disable-next-line */
     var t = btoa(GITHUB_API_TOKEN)
     /* eslint-disable-next-line */
-    this.fetcher = new GithubFetcher(btoa(t))
+    this.fetcher = new GithubFetcher(t)
     this.props.updateState("githubApiToken", t)
 
     this.search = _.debounce(

--- a/src/reducers/github.js
+++ b/src/reducers/github.js
@@ -11,8 +11,7 @@ const INITIAL_STATE = {
   releaseData: [],
   releaseStats: {},
 
-  githubApiToken: 'Z2hwX29XQWdNS3gxeXNHRXBlTzV6OEdpdWZvNjc0WkhWZTN0bVlJVQ==',
-
+  githubApiToken: btoa(process.env.REACT_APP_GITHUB_API_TOKEN),
 }
 
 const github = (state = INITIAL_STATE, action) => {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/github-statistics/issues/70

#### Description:
value of githubApiToken in `INITIAL_STATE` and `process.env.REACT_APP_GITHUB_API_TOKEN` not same, which leads to **miss-setting** token when **new `GithubFetcher(t)**.

And local run get `401 bad credentials`

<img width="1512" alt="image" src="https://github.com/vesoft-inc/github-statistics/assets/9915368/025cf42a-d31d-4b7a-8777-e546aa1c4eda">

## How do you solve it?

unify githubApiToken to `btoa(process.env.REACT_APP_GITHUB_API_TOKEN)`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


